### PR TITLE
Inline `withFilter` now expects an `F[L]`

### DIFF
--- a/src/main/scala/no/scalabin/http4s/directives/DirectiveOps.scala
+++ b/src/main/scala/no/scalabin/http4s/directives/DirectiveOps.scala
@@ -6,7 +6,7 @@ import scala.language.higherKinds
 
 trait DirectiveOps[F[+ _]] {
   implicit class FilterSyntax(b: Boolean) {
-    def |[L](failure: => L) = Directive.Filter(b, () => failure)
+    def orF[L](failureF: F[L]) = Directive.Filter(b, failureF)
   }
 
   implicit class MonadDecorator[+X](f: F[X])(implicit sync: Monad[F]) {

--- a/src/main/scala/no/scalabin/http4s/directives/Directives.scala
+++ b/src/main/scala/no/scalabin/http4s/directives/Directives.scala
@@ -37,7 +37,7 @@ class Directives[F[+ _]: Monad] {
 
   def getOrElse[A, L](opt: Option[A], orElse: => F[L]) = directives.Directive.getOrElse[F, L, A](opt, orElse)
 
-  type Filter[+L] = directives.Directive.Filter[L]
+  type Filter[+L] = directives.Directive.Filter[F, L]
   val Filter = directives.Directive.Filter
 
   val commit = directives.Directive.commit

--- a/src/test/scala/no/scalabin/http4s/directives/Main.scala
+++ b/src/test/scala/no/scalabin/http4s/directives/Main.scala
@@ -29,6 +29,8 @@ object Main extends StreamApp[IO] {
           for {
             _   <- Method.GET
             res <- Conditional.ifModifiedSince(lm, Ok("Hello World"))
+            foo <- request.queryParam[IO]("foo")
+            if foo.isDefined orF BadRequest("You didn't provide a foo, you fool!")
             //res <- Ok("Hello world")
           } yield res
         }


### PR DESCRIPTION
This is more natural in http4s, being that all responses are in practice an effect.
Also the operator got renamed to `orF`, to remove both user and compiler confusion, from the previous `|` and highlighting that an effect is required.