### PR TITLE
changed type signature of directive when lifting F[Response[F]] into one

### DIFF
--- a/src/main/scala/no/scalabin/http4s/directives/Directive.scala
+++ b/src/main/scala/no/scalabin/http4s/directives/Directive.scala
@@ -66,13 +66,13 @@ object Directive {
 
   def error[F[_]: Monad, A](error: => Response[F]): Directive[F, A] = result[F, A](Result.error[F, A](error))
 
-  def liftF[F[_]: Monad, X](f: F[X]): Directive[F, X] = Directive[F, X](_ => f.map(Result.Success(_)))
+  def liftF[F[_]: Monad, A](f: F[A]): Directive[F, A] = Directive[F, A](_ => f.map(Result.Success(_)))
 
-  def successF[F[_]: Monad, X](f: F[X]): Directive[F, X] = liftF(f)
+  def successF[F[_]: Monad, A](f: F[A]): Directive[F, A] = liftF(f)
 
-  def failureF[F[_]: Monad, X](f: F[Response[F]]): Directive[F, X] = Directive[F, X](_ => f.map(Result.Failure[F, X]))
+  def failureF[F[_]: Monad, A](f: F[Response[F]]): Directive[F, A] = Directive[F, A](_ => f.map(Result.Failure[F, A]))
 
-  def errorF[F[_]: Monad, X](f: F[Response[F]]): Directive[F, X] = Directive[F, X](_ => f.map(Result.Error[F, X]))
+  def errorF[F[_]: Monad, A](f: F[Response[F]]): Directive[F, A] = Directive[F, A](_ => f.map(Result.Error[F, A]))
 
   case class Filter[F[_]](result: Boolean, failure: F[Response[F]])
 

--- a/src/main/scala/no/scalabin/http4s/directives/Directives.scala
+++ b/src/main/scala/no/scalabin/http4s/directives/Directives.scala
@@ -28,10 +28,10 @@ class Directives[F[_]: Monad] {
   def failure[A](failure: Response[F]) = directives.Directive.failure[F, A](failure)
   def error[A](error: Response[F])     = directives.Directive.error[F, A](error)
 
-  def liftF[A](success: F[A])           = directives.Directive.liftF[F, A](success)
-  def successF[A](success: F[A])        = liftF(success)
-  def failureF(failure: F[Response[F]]) = directives.Directive.failureF[F, Response[F]](failure)
-  def errorF(error: F[Response[F]])     = directives.Directive.errorF[F, Response[F]](error)
+  def liftF[A](success: F[A])              = directives.Directive.liftF[F, A](success)
+  def successF[A](success: F[A])           = liftF(success)
+  def failureF[A](failure: F[Response[F]]) = directives.Directive.failureF[F, A](failure)
+  def errorF[A](error: F[Response[F]])     = directives.Directive.errorF[F, A](error)
 
   def getOrElseF[A](opt: F[Option[A]], orElse: => F[Response[F]]) = directives.Directive.getOrElseF(opt, orElse)
 


### PR DESCRIPTION
when lifting a `F[Response[F]]` into a failure or error directive, the directive should be type parametrised with type `A` instead of the given contained `Response[F]` type.