### PR TITLE
Lock down F type to avoid confusion in usage

### DIFF
--- a/src/main/scala/no/scalabin/http4s/directives/RequestDirectives.scala
+++ b/src/main/scala/no/scalabin/http4s/directives/RequestDirectives.scala
@@ -20,68 +20,69 @@ trait RequestDirectives[F[_]] {
     def directive: Directive[F, Option[key.HeaderT]] = liftHeaderDirective(key)
   }
 
-  object request extends RequestOps
+  object request extends RequestOps[F]
 }
 
-trait RequestOps {
+trait RequestOps[F[_]] {
 
-  def headers[F[_]: Monad]: Directive[F, Headers] = Directive.request.map(_.headers)
+  def headers(implicit M: Monad[F]): Directive[F, Headers] = Directive.request.map(_.headers)
 
-  def header[F[_]: Monad, KEY <: HeaderKey](key: KEY): Directive[F, Option[key.HeaderT]] =
+  def header[KEY <: HeaderKey](key: KEY)(implicit M: Monad[F]): Directive[F, Option[key.HeaderT]] =
     headers.map(_.get(key.name)).map(_.flatMap(h => key.matchHeader(h)))
 
-  def headerOrElse[F[_]: Monad, KEY <: HeaderKey](key: KEY, orElse: => Response[F]): Directive[F, key.HeaderT] =
+  def headerOrElse[KEY <: HeaderKey](key: KEY, orElse: => Response[F])(implicit M: Monad[F]): Directive[F, key.HeaderT] =
     headerOrElseF(key, Monad[F].pure(orElse))
 
-  def headerOrElseF[F[_]: Monad, KEY <: HeaderKey](key: KEY, orElse: F[Response[F]]): Directive[F, key.HeaderT] =
+  def headerOrElseF[KEY <: HeaderKey](key: KEY, orElse: F[Response[F]])(implicit M: Monad[F]): Directive[F, key.HeaderT] =
     header(key).flatMap(opt => Directive.getOrElseF(opt, orElse))
 
-  def header[F[_]: Monad](key: String): Directive[F, Option[Header]] = headers.map(_.get(CaseInsensitiveString(key)))
+  def header(key: String)(implicit M: Monad[F]): Directive[F, Option[Header]] = headers.map(_.get(CaseInsensitiveString(key)))
 
-  def headerOrElse[F[_]: Monad](key: String, orElse: => Response[F]): Directive[F, Header] =
-    headerOrElseF(key, Monad[F].pure(orElse))
+  def headerOrElse(key: String, orElse: => Response[F])(implicit M: Monad[F]): Directive[F, Header] =
+    headerOrElseF(key, M.pure(orElse))
 
-  def headerOrElseF[F[_]: Monad](key: String, orElse: F[Response[F]]): Directive[F, Header] =
+  def headerOrElseF(key: String, orElse: F[Response[F]])(implicit M: Monad[F]): Directive[F, Header] =
     header(key).flatMap(opt => Directive.getOrElseF(opt, orElse))
 
-  def cookies[F[_]: Monad]: Directive[F, Option[NonEmptyList[RequestCookie]]] =
+  def cookies(implicit M: Monad[F]): Directive[F, Option[NonEmptyList[RequestCookie]]] =
     header(org.http4s.headers.Cookie).map(_.map(_.values))
 
-  def cookiesAsList[F[_]: Monad]: Directive[F, List[RequestCookie]] =
+  def cookiesAsList(implicit M: Monad[F]): Directive[F, List[RequestCookie]] =
     cookies.map(_.toList.flatMap(_.toList))
 
-  def cookiesOrElse[F[_]: Monad](orElse: => Response[F]): Directive[F, NonEmptyList[RequestCookie]] =
-    cookiesOrElseF(Monad[F].pure(orElse))
+  def cookiesOrElse(orElse: => Response[F])(implicit M: Monad[F]): Directive[F, NonEmptyList[RequestCookie]] =
+    cookiesOrElseF(M.pure(orElse))
 
-  def cookiesOrElseF[F[_]: Monad](orElse: F[Response[F]]): Directive[F, NonEmptyList[RequestCookie]] =
+  def cookiesOrElseF(orElse: F[Response[F]])(implicit M: Monad[F]): Directive[F, NonEmptyList[RequestCookie]] =
     cookies.flatMap(opt => Directive.getOrElseF(opt, orElse))
 
-  def cookie[F[_]: Monad](name: String): Directive[F, Option[RequestCookie]] =
+  def cookie(name: String)(implicit M: Monad[F]): Directive[F, Option[RequestCookie]] =
     cookies.map(_.flatMap(_.find(c => c.name == name)))
 
-  def cookieOrElse[F[_]: Monad](name: String, orElse: => Response[F]): Directive[F, RequestCookie] =
+  def cookieOrElse(name: String, orElse: => Response[F])(implicit M: Monad[F]): Directive[F, RequestCookie] =
     cookie(name).flatMap(opt => Directive.getOrElse(opt, orElse))
 
-  def cookieOrElseF[F[_]: Monad](name: String, orElse: F[Response[F]]): Directive[F, RequestCookie] =
+  def cookieOrElseF(name: String, orElse: F[Response[F]])(implicit M: Monad[F]): Directive[F, RequestCookie] =
     cookie(name).flatMap(opt => Directive.getOrElseF(opt, orElse))
 
-  def uri[F[_]: Monad]: Directive[F, Uri]       = Directive.request.map(_.uri)
-  def path[F[_]: Monad]: Directive[F, Uri.Path] = uri.map(_.path)
-  def query[F[_]: Monad]: Directive[F, Query]   = uri.map(_.query)
+  def uri(implicit M: Monad[F]): Directive[F, Uri]       = Directive.request.map(_.uri)
+  def path(implicit M: Monad[F]): Directive[F, Uri.Path] = uri.map(_.path)
+  def query(implicit M: Monad[F]): Directive[F, Query]   = uri.map(_.query)
 
-  def queryParams[F[_]: Monad](name: String): Directive[F, Seq[String]]   = query.map(_.multiParams.getOrElse(name, Nil))
-  def queryParam[F[_]: Monad](name: String): Directive[F, Option[String]] = query.map(_.params.get(name))
-  def queryParamOrElse[F[_]: Monad](name: String, orElse: => Response[F]): Directive[F, String] =
-    queryParamOrElseF(name, Monad[F].pure(orElse))
+  def queryParams(name: String)(implicit M: Monad[F]): Directive[F, Seq[String]]   = query.map(_.multiParams.getOrElse(name, Nil))
+  def queryParam(name: String)(implicit M: Monad[F]): Directive[F, Option[String]] = query.map(_.params.get(name))
+  def queryParamOrElse(name: String, orElse: => Response[F])(implicit M: Monad[F]): Directive[F, String] =
+    queryParamOrElseF(name, M.pure(orElse))
 
-  def queryParamOrElseF[F[_]: Monad](name: String, orElse: F[Response[F]]): Directive[F, String] = queryParam(name).flatMap(
-    opt => Directive.getOrElseF(opt, orElse)
-  )
+  def queryParamOrElseF(name: String, orElse: F[Response[F]])(implicit M: Monad[F]): Directive[F, String] =
+    queryParam(name).flatMap(
+      opt => Directive.getOrElseF(opt, orElse)
+    )
 
-  def bodyAs[F[_]: Sync, A](implicit dec: EntityDecoder[F, A]): Directive[F, A] =
+  def bodyAs[A](implicit dec: EntityDecoder[F, A], M: Sync[F]): Directive[F, A] =
     bodyAs(_ => Response[F](Status.InternalServerError))
 
-  def bodyAs[F[_]: Sync, A](onError: DecodeFailure => Response[F])(implicit dec: EntityDecoder[F, A]): Directive[F, A] = {
+  def bodyAs[A](onError: DecodeFailure => Response[F])(implicit dec: EntityDecoder[F, A], M: Sync[F]): Directive[F, A] = {
     Directive(
       req =>
         req

--- a/src/main/tut/docs/usage.md
+++ b/src/main/tut/docs/usage.md
@@ -44,7 +44,7 @@ val bodyService = HttpRoutes.of[IO] {
     case Root / "hello" => 
       for {
         _    <- Method.POST
-        body <- request.bodyAs[IO, String]
+        body <- request.bodyAs[String]
         r    <- Ok(s"echo $body").successF
       } yield r
   }
@@ -58,9 +58,9 @@ val queryParamService = HttpRoutes.of[IO] {
     case Root / "hello" => 
       for {
         _         <- Method.POST
-        name      <- request.queryParam[IO]("name")
-        items     <- request.queryParams[IO]("items")
-        nickname  <- request.queryParamOrElseF[IO]("nickname", BadRequest("missing nickname"))
+        name      <- request.queryParam("name")
+        items     <- request.queryParams("items")
+        nickname  <- request.queryParamOrElseF("nickname", BadRequest("missing nickname"))
         r         <- Ok(s"Hello $name($nickname): ${items.mkString(",")}").successF
       } yield r
   }

--- a/src/test/scala/no/scalabin/http4s/directives/DirectivesSpec.scala
+++ b/src/test/scala/no/scalabin/http4s/directives/DirectivesSpec.scala
@@ -70,8 +70,8 @@ class DirectivesSpec extends FlatSpec with Matchers {
         case Root / "hello" =>
           for {
             _   <- Method.GET
-            res <- Conditional.ifModifiedSinceF(lastModifiedTime, Ok("Hello World"))
-            foo <- request.queryParam[IO]("foo")
+            res <- Conditional[IO].ifModifiedSinceF(lastModifiedTime, Ok("Hello World"))
+            foo <- request.queryParam("foo")
             if foo.isDefined orF BadRequest("You didn't provide a foo, you fool!")
           } yield res
       }

--- a/src/test/scala/no/scalabin/http4s/directives/Main.scala
+++ b/src/test/scala/no/scalabin/http4s/directives/Main.scala
@@ -8,7 +8,6 @@ import org.http4s._
 import org.http4s.dsl.impl.Root
 import org.http4s.dsl.io._
 import org.http4s.implicits._
-import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
 
 object Main extends IOApp {
@@ -29,8 +28,8 @@ object Main extends IOApp {
           case Root / "hello" => {
             for {
               _   <- Method.GET
-              res <- Conditional.ifModifiedSinceF(lm, Ok("Hello World"))
-              foo <- request.queryParam[IO]("foo")
+              res <- Conditional[IO].ifModifiedSinceF(lm, Ok("Hello World"))
+              foo <- request.queryParam("foo")
               if foo.isDefined orF BadRequest("You didn't provide a foo, you fool!")
               //res <- Ok("Hello world")
             } yield res


### PR DESCRIPTION
We should lock down the F[_] context as early as possible to avoid having to repeat ourselves